### PR TITLE
Use Finnish capitalization rules for names

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -12,12 +12,13 @@ function capitalizeProperly(streetname){
 }
 
 function cleanupStreetName(input) {
-  return input.split(/\s/)
-  .map(removeLeadingZerosFromStreet)
-  .filter(function(part){
-    return part.length > 0;
-  }).map(capitalizeProperly)
-  .join(' ');
+  return capitalizeProperly(
+    input.split(/\s/)
+    .map(removeLeadingZerosFromStreet)
+    .filter(function(part){
+      return part.length > 0;
+    }).join(' ')
+  );
 }
 
 module.exports = {

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -131,14 +131,14 @@
     "_id": "data/input_file_2:REMOVES LEADING ZEROES",
     "data": {
       "name": {
-        "default": "500 Calle De Lago"
+        "default": "500 Calle de Lago"
       },
       "phrase": {
-        "default": "500 Calle De Lago"
+        "default": "500 Calle de Lago"
       },
       "address_parts": {
         "number": "500",
-        "street": "Calle De Lago"
+        "street": "Calle de Lago"
       },
       "center_point": {
         "lon": 91.919191,

--- a/test/streams/cleanupStream.js
+++ b/test/streams/cleanupStream.js
@@ -112,7 +112,7 @@ tape ( 'cleanupStream trims white space in street field', function(test){
     }];
     var expecteds = [{
       NUMBER: '88',
-      STREET: 'Glasgow Street'
+      STREET: 'Glasgow street'
     },
     {
       NUMBER: '76',
@@ -124,7 +124,7 @@ tape ( 'cleanupStream trims white space in street field', function(test){
     },
     {
       NUMBER: '314',
-      STREET: 'Timid Street' //should capitalize first letter of each word
+      STREET: 'Timid street' //should capitalize first letter of each word
     },
     {
       NUMBER: '4',

--- a/test/streams/recordStream.js
+++ b/test/streams/recordStream.js
@@ -1,3 +1,4 @@
+
 var tape = require( 'tape' );
 var through = require( 'through2' );
 
@@ -23,8 +24,8 @@ tape(
       createTestRec( -118.79719936, 55.153343057595535, '712068 Rge Road 34' ),
       createTestRec( -118.66743097, 55.151807043809917, '712060 Rge Road 34' ),
       createTestRec( -118.74783569, 55.155320792497442, '712082 Rge Road 35' ),
-      createTestRec( 1, 2, 'number Too Many Spaces' ),
-      createTestRec( 1, 2, 'trim Multiple Spaces' )
+      createTestRec( 1, 2, 'number Too many spaces' ),
+      createTestRec( 1, 2, 'trim Multiple spaces' )
     ];
     test.plan( expectedRecords.length * 4 + 1);
 


### PR DESCRIPTION
OpenAddresses importer incorrectly capitalized all words in names. For example:

   Bertel Jungin tie 1 -> Bertel Jungin Tie 1

